### PR TITLE
Fix Dockerfile: Replace deprecated openjdk base image with amazoncorretto:17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ COPY src /home/app/src
 COPY pom.xml /home/app
 RUN mvn -f /home/app/pom.xml clean package -DskipTests
 
-FROM openjdk:17
+FROM amazoncorretto:17
 COPY --from=build /home/app/target/runflutterrun-0.0.1-SNAPSHOT.jar /usr/local/lib/runflutterrun.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/usr/local/lib/runflutterrun.jar"]


### PR DESCRIPTION
# Fix Dockerfile: Replace deprecated openjdk base image with amazoncorretto:17

## Summary
This PR updates the Dockerfile to replace the deprecated or unavailable `openjdk:17`/`openjdk:17-jdk` base image with `amazoncorretto:17`. This resolves Docker build errors due to missing manifests for the previous base images and ensures consistent JDK vendor usage in both the build and runtime stages.

## Details
- Changed the runtime stage in the Dockerfile from:
  - `FROM openjdk:17` **or** `FROM openjdk:17-jdk`
  - to: `FROM amazoncorretto:17`
- Fixes image pull/build error:
  ```
  MANIFEST_UNKNOWN: manifest unknown; unknown tag=17-jdk
  ```
- Keeping both build and runtime stages on Corretto 17 improves compatibility and stability.

## How to verify
- Rebuild and redeploy the Docker image.
- The image build should complete successfully without manifest/tag errors.
- The application should launch normally on port 8080.

---